### PR TITLE
feat: Add Ghostty support for command log pane hooks

### DIFF
--- a/dot_claude/README.md
+++ b/dot_claude/README.md
@@ -39,3 +39,42 @@ chezmoi で管理する Claude Code の設定ディレクトリ。
 | run_after_merge.sh | commands/skills をマージするスクリプト |
 | settings.json | 権限設定、hooks 等 |
 | statusline.sh | ステータスライン表示スクリプト |
+| hooks/cmux-command-log.sh | Bash コマンド実行ログを記録する PostToolUse hook |
+| hooks/cmux-log-pane.sh | セッション開始時にログ表示ペインを自動作成する SessionStart hook |
+| hooks/protect-branches.sh | 保護ブランチへの直接コミットをブロックする PreToolUse hook |
+
+## コマンドログ (hooks/cmux-command-log.sh, hooks/cmux-log-pane.sh)
+
+Claude Code が実行した Bash コマンドをリアルタイムで別ペイン/ウィンドウに表示する仕組み。
+
+### 環境変数
+
+| 変数 | 値 | 説明 |
+|------|---|------|
+| `CLAUDE_COMMAND_LOG` | `1` | コマンドログを有効化 |
+| `CLAUDE_LOG_PANE_MODE` | `window` (デフォルト) | Ghostty の新ウィンドウで表示 |
+| `CLAUDE_LOG_PANE_MODE` | `split` | Ghostty のスプリットペインで表示 |
+
+### 使い方
+
+```bash
+# window モード（デフォルト）- 新ウィンドウで tail -f
+CLAUDE_COMMAND_LOG=1 claude
+
+# split モード - Ghostty スプリットで tail -f
+CLAUDE_COMMAND_LOG=1 CLAUDE_LOG_PANE_MODE=split claude
+```
+
+### 動作の仕組み
+
+1. **cmux-command-log.sh** (PostToolUse): Bash ツール実行ごとにコマンドと出力先頭5行を `/tmp/claude-command-logs/<session_id>.log` に追記
+2. **cmux-log-pane.sh** (SessionStart): セッション開始時にログファイルを `tail -f` するペインを自動作成
+
+### モード別の詳細
+
+- **window**: `open -na Ghostty.app --args -e bash -c "tail -f ..."` で新ウィンドウを起動。AppleScript 不要
+- **split**: AppleScript で `Cmd+Shift+D` (new_split:down) を送信し、クリップボード経由でコマンドをペースト。システム環境設定 > プライバシーとセキュリティ > アクセシビリティ で Ghostty の許可が必要。split 中に一時的にクリップボードを使用する（完了後に復元）
+
+### 旧 cmux 対応
+
+ファイル名に `cmux` が残っているが、現在は Ghostty 向け。cmux コードはコメントアウトで保持しており、`CMUX_COMMAND_LOG=1` も後方互換で動作する

--- a/dot_claude/hooks/executable_cmux-command-log.sh
+++ b/dot_claude/hooks/executable_cmux-command-log.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 # PostToolUse hook: Bash コマンドと出力先頭をログファイルに追記
-# cmux ペインで tail -f して表示する想定
-# CMUX_COMMAND_LOG=1 で有効化。セッションごとに別ファイルに出力。
+# Ghostty / cmux ペインで tail -f して表示する想定
+# CLAUDE_COMMAND_LOG=1 で有効化。セッションごとに別ファイルに出力。
+# (旧: CMUX_COMMAND_LOG=1 でも有効)
 
 set -euo pipefail
 
-[[ "${CMUX_COMMAND_LOG:-}" == "1" ]] || exit 0
+[[ "${CLAUDE_COMMAND_LOG:-${CMUX_COMMAND_LOG:-}}" == "1" ]] || exit 0
 
 INPUT=$(cat)
 

--- a/dot_claude/hooks/executable_cmux-log-pane.sh
+++ b/dot_claude/hooks/executable_cmux-log-pane.sh
@@ -1,11 +1,19 @@
 #!/usr/bin/env bash
-# SessionStart hook: cmux 内なら下にペインを生やして tail -f でログを表示
-# CMUX_COMMAND_LOG=1 のときのみ動作
+# SessionStart hook: ターミナルにペインを生やして tail -f でログを表示
+# CLAUDE_COMMAND_LOG=1 のときのみ動作
+#
+# CLAUDE_LOG_PANE_MODE で表示方法を切り替え:
+#   split  - Ghostty スプリット (AppleScript 経由、アクセシビリティ許可が必要)
+#   window - Ghostty 新ウィンドウ (AppleScript 不要)
+#   (デフォルト: window)
+#
+# 対応ターミナル:
+#   - Ghostty (macOS): split / window
+#   - cmux: cmux new-split (コメントアウト中)
 
 set -euo pipefail
 
-[[ "${CMUX_COMMAND_LOG:-}" == "1" ]] || exit 0
-[[ -n "${CMUX_SOCKET_PATH:-}" ]] || exit 0
+[[ "${CLAUDE_COMMAND_LOG:-${CMUX_COMMAND_LOG:-}}" == "1" ]] || exit 0
 
 INPUT=$(cat)
 
@@ -17,10 +25,64 @@ mkdir -p "$LOGDIR"
 LOGFILE="${LOGDIR}/${SESSION_ID}.log"
 touch "$LOGFILE"
 
-# 下にペインを生やして tail -f を実行
-RESULT=$(cmux new-split down)
-SURFACE=$(echo "$RESULT" | awk '{print $2}')
+PANE_MODE="${CLAUDE_LOG_PANE_MODE:-window}"
 
-cmux send --surface "$SURFACE" "tail -f $LOGFILE\n"
+# --- Ghostty (macOS) ---
+if [[ "${TERM_PROGRAM:-}" == "ghostty" ]]; then
+  case "$PANE_MODE" in
+    split)
+      # AppleScript で Cmd+Shift+D (new_split:down) → クリップボード経由でコマンド送信
+      # keystroke は IME を通過するため、クリップボードにコマンドを入れて Cmd+V で貼り付け
+      # システム環境設定 > アクセシビリティ で Ghostty への許可が必要
+      TAIL_CMD="tail -f ${LOGFILE}"
+      osascript <<APPLESCRIPT
+        -- 現在のクリップボードを退避
+        set oldClipboard to the clipboard
+
+        tell application "System Events"
+          tell process "ghostty"
+            -- Cmd+Shift+D = new_split:down
+            keystroke "d" using {command down, shift down}
+          end tell
+        end tell
+
+        delay 0.5
+
+        -- クリップボードにコマンドをセットして貼り付け
+        set the clipboard to "${TAIL_CMD}"
+        tell application "System Events"
+          tell process "ghostty"
+            keystroke "v" using {command down}
+          end tell
+        end tell
+
+        delay 0.2
+
+        tell application "System Events"
+          tell process "ghostty"
+            key code 36 -- Return
+          end tell
+        end tell
+
+        -- クリップボードを復元
+        delay 0.2
+        set the clipboard to oldClipboard
+APPLESCRIPT
+      ;;
+    window|*)
+      # 新ウィンドウで tail -f を実行 (AppleScript 不要)
+      open -na Ghostty.app --args -e /bin/bash -c "exec tail -f '${LOGFILE}'"
+      ;;
+  esac
+  exit 0
+fi
+
+# --- cmux: コメントアウト中（戻す場合は下記を有効化） ---
+# if [[ -n "${CMUX_SOCKET_PATH:-}" ]]; then
+#   RESULT=$(cmux new-split down)
+#   SURFACE=$(echo "$RESULT" | awk '{print $2}')
+#   cmux send --surface "$SURFACE" "tail -f $LOGFILE\n"
+#   exit 0
+# fi
 
 exit 0


### PR DESCRIPTION
## Summary

- cmux 依存のコマンドログ表示を Ghostty 対応に置き換え
- `CLAUDE_LOG_PANE_MODE` で window（新ウィンドウ）/ split（スプリットペイン）を切り替え可能
- cmux コードはコメントアウトで保持（ロールバック可能）

## 変更ファイル

- `hooks/executable_cmux-command-log.sh`: 環境変数を `CLAUDE_COMMAND_LOG` に変更（`CMUX_COMMAND_LOG` も互換）
- `hooks/executable_cmux-log-pane.sh`: Ghostty window/split モード対応
- `README.md`: コマンドログ機能のドキュメント追加

## Test plan

- [x] `CLAUDE_COMMAND_LOG=1 claude` で window モード動作確認済み
- [x] `CLAUDE_COMMAND_LOG=1 CLAUDE_LOG_PANE_MODE=split claude` で split モード動作確認済み