### PR TITLE
feat: add .terraformrc with plugin cache

### DIFF
--- a/dot_terraformrc
+++ b/dot_terraformrc
@@ -1,0 +1,1 @@
+plugin_cache_dir = "$HOME/.terraform.d/plugin-cache"


### PR DESCRIPTION
## Summary

- Terraform provider バイナリを `~/.terraform.d/plugin-cache/` に集約する `plugin_cache_dir` 設定を追加
- 各 terraform/terragrunt ディレクトリへの provider 重複コピーを防止し、ディスク使用量を大幅に削減

## Background

- plugin cache 有効化により、次回以降の `terraform init` では provider を1箇所に保持しシンボリンクで参照する